### PR TITLE
feat(upgrade): 升级依赖包babel-core为@babel/core

### DIFF
--- a/lib/utils/memorizer.js
+++ b/lib/utils/memorizer.js
@@ -1,5 +1,5 @@
 const compiler = require('vue-template-compiler')
-const { transform } = require('babel-core')
+const { transform } = require('@babel/core')
 const { parseScript } = require('./babel-parser')
 const { inspectFile } = require('./util')
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Tee Jay <tjeeay@outlook.com>",
   "license": "MIT",
   "dependencies": {
-    "babel-core": "^6.26.3",
+    "@babel/core": "7.10.2",
     "babel-generator": "^6.26.1",
     "babel-types": "^6.26.0",
     "babelon": "^1.0.5",


### PR DESCRIPTION
依赖包babel-core中引用了工具依赖包babylon，babylon只支持ES2017语法不支持最新的ES语法。故升级babel-core为@babel/core（现为babel的核心子包），升级后的@babel/core不依赖babylon。在执行Vue文件代码向小程序文件代码代码编译时，Vue文件中就能使用最新的ES语法啦。